### PR TITLE
Formalises testing and removes 'strict' errors

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/Legal.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Legal.pm
@@ -34,11 +34,22 @@ __[ xt/release/test-legal.t ]__
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More qw(no_plan);
 
-eval 'use Test::Legal';
-plan skip_all => 'Test::Legal required for testing licenses'
-  if $@
+ SKIP: {
 
-copyright_ok;
-license_ok;
+     eval { require Test::Legal };	
+
+     skip "Test::Legal required for testing licences" if $@;
+     
+     eval { Test::Legal->import() };
+	
+     BAIL_OUT "Test::Legal reported error on import so aborting tests: $@" if $@;
+
+     can_ok( __PACKAGE__, qw(copyright_ok license_ok) );
+     
+     main->copyright_ok;
+     
+     main->license_ok;
+     
+};


### PR DESCRIPTION
Doing the pull-request challenge with Neil Bowers and was looking at 'strict' errors reported as an issue in the generated test file.
Took it as an opportunity to formalise the testing in the created test file after reading up on Test::More.